### PR TITLE
Enumerate input/graphics devices with udev

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you are not using Arch Linux you can try to manually install with meson
 * Bubblewrap (>= 0.5.0) - sandboxing command line utility
 * XDG D-Bus Proxy - filtering dbus proxy
 * Desktop File Utils - to manipulate default applications
+* Python udev - device detection
 * Python Qt5 - for GUI
 * Meson - build system
 * m4 - macro generator used during build


### PR DESCRIPTION
We can query udev to get a list of devices more reliably and simply. For example, the previous code does not detect controllers unless the joydev module (old API) is loaded, whereas udev has already labeled the correct event*, input*, and js* devices with `ID_INPUT_JOYSTICK`.

The same approach can probably be used for video/media devices, but I didn't feel as confident with how to make that change.

The added pyudev dependency is documented in the README.