### PR TITLE
Added install tags for meson

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -2,37 +2,44 @@
 install_data(
     'bubblejail-config.png',
     install_dir : get_option('datadir') / 'icons/hicolor/48x48/apps',
+    install_tag : 'bubblejail-gui',
 )
 
 install_data(
     'bubblejail-config.svg',
     install_dir : get_option('datadir') / 'icons/hicolor/scalable/apps',
+    install_tag : 'bubblejail-gui',
 )
 
 install_data(
     'bubblejail-config.desktop',
     install_dir : get_option('datadir') / 'applications',
+    install_tag : 'bubblejail-gui',
 )
 
 install_subdir(
     'usr-share/bubblejail',
     install_dir : get_option('datadir'),
+    install_tag : 'runtime'
 )
 
 install_subdir(
     'etc/bubblejail',
     install_dir : get_option('sysconfdir'),
     exclude_files : ['profiles/.gitkeep'],
+    install_tag : 'runtime'
 )
 
 install_data(
     'bubblejail_completion.bash',
     install_dir : get_option('datadir') / 'bash-completion/completions',
     rename : 'bubblejail',
+    install_tag : 'bash-completion',
 )
 
 install_data(
     'bubblejail_completion.fish',
     install_dir : get_option('datadir') / 'fish/vendor_completions.d',
     rename : 'bubblejail.fish',
+    install_tag : 'fish-completion',
 )

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -32,6 +32,7 @@ bubblejail_man_page = custom_target(
     install : get_option('man'),
     install_dir : get_option('mandir') / 'man1',
     command : scdoc,
+    install_tag : 'man'
 )
 
 bubblejail_services_man_page_markdown = custom_target(
@@ -60,4 +61,5 @@ bubblejail_services_man_page = custom_target(
     install : get_option('man'),
     install_dir : get_option('mandir') / 'man5',
     command : scdoc,
+    install_tag : 'man'
 )

--- a/src/bubblejail/meson.build
+++ b/src/bubblejail/meson.build
@@ -34,6 +34,7 @@ bubblejail_lib_package = custom_target(
     output : source_files + ['__pycache__'],
     install : true,
     install_dir : bubblejail_package_dir,
+    install_tag : 'runtime',
     command : [
         bytecode_compiler,
         '--input-files', '@INPUT@',

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -64,6 +64,7 @@ bubblejail_cli_launch = custom_target(
     install : true,
     install_dir : get_option('bindir'),
     install_mode : 'rwxr-xr-x',
+    install_tag : 'runtime',
     command : jinja2_commands,
 )
 
@@ -80,6 +81,7 @@ bubblejail_gui_qt_launch = custom_target(
     install : true,
     install_dir : get_option('bindir'),
     install_mode : 'rwxr-xr-x',
+    install_tag : 'bubblejail-gui',
     command : jinja2_commands,
 )
 
@@ -95,6 +97,7 @@ bubblejail_helper_launch = custom_target(
     capture : true,
     install : true,
     install_dir : get_option('libdir') / 'bubblejail',
+    install_tag : 'runtime',
     install_mode : 'rwxr-xr-x',
     command : jinja2_commands,
 )


### PR DESCRIPTION
Files that are installed by meson are now tagged with install tags: `runtime` for core files and cli tool, `bubblejail-gui` for gui configuration tool, `fish-completion`/`bash-completion` for shell autocompletion, `man` for man pages.
