### PR TITLE
Don't set notification urgency to critical

### DIFF
--- a/src/bubblejail/bubblejail_cli.py
+++ b/src/bubblejail/bubblejail_cli.py
@@ -129,7 +129,6 @@ def run_bjail(instance_name: str,
                 subprocess_run(
                     (
                         'notify-send',
-                        '--urgency', 'critical',
                         '--icon', 'bubblejail-config',
                         f"Failed to run instance: {instance_name}",
                         f"Exception: {format_exc(0)}"


### PR DESCRIPTION
Currently, notification urgency is set to critical, which makes the notification permanent until manually dismissed by the user.  This PR removes the urgency setting so that the notification can be allowed to time out according to users' notification setting.  Most notification systems include a history that the user can review if the notification contents are needed after it times out.