### PR TITLE
Add variable expansion to root_share and debug services

### DIFF
--- a/src/bubblejail/bwrap_config.py
+++ b/src/bubblejail/bwrap_config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from os import environ
+from os import environ, path
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -143,7 +143,7 @@ class BwrapRawArgs(BwrapConfigBase):
 
     def __init__(self, raw_args: list[str]):
         super().__init__()
-        self.raw_args = raw_args
+        self.raw_args = list(map(path.expandvars, raw_args))
 
     def to_args(self) -> Generator[str, None, None]:
         yield from self.raw_args

--- a/src/bubblejail/services.py
+++ b/src/bubblejail/services.py
@@ -15,7 +15,7 @@ from enum import IntFlag
 from enum import auto as enum_auto
 from functools import cache
 from multiprocessing import Process
-from os import O_CLOEXEC, O_NONBLOCK, environ, getpid, getuid, pipe2, readlink
+from os import O_CLOEXEC, O_NONBLOCK, environ, getpid, getuid, path, pipe2, readlink
 from pathlib import Path
 from shutil import which
 from sys import stderr
@@ -722,9 +722,9 @@ class RootShare(BubblejailService):
 
         for x in all_paths:
             if x in read_write_paths:
-                yield Bind(x)
+                yield Bind(path.expandvars(x))
             elif x in read_only_paths:
-                yield ReadOnlyBind(x)
+                yield ReadOnlyBind(path.expandvars(x))
             else:
                 raise ValueError
 


### PR DESCRIPTION
Uses `os.path.expandvars()` to expand variables in root_share and debug services.

Tested with `$HOME` variable and non-variable `$TEST`.  Existing configs containing `$` will not break as long as the word does not correspond to a variable.

Closes #61