### PR TITLE
feat: detect more firefox variants

### DIFF
--- a/data/usr-share/bubblejail/profiles/firefox_wayland.toml
+++ b/data/usr-share/bubblejail/profiles/firefox_wayland.toml
@@ -5,6 +5,9 @@
 dot_desktop_path = [
     "/usr/share/applications/firefox.desktop",
     "/usr/share/applications/firefox-esr.desktop",
+    "/usr/share/applications/org.mozilla.firefox.desktop",
+    "/usr/share/applications/librewolf.desktop",
+    "/usr/share/applications/io.gitlab.librewolf.desktop"
 ]
 is_gtk_application = true
 description='''


### PR DESCRIPTION
detects Fedora Firefox, and Librewolf in 2 different formats

one may be redundant but with the current logic (blocking creation when not found) should be harmless

fixes #130