### PR TITLE
feat: detect Vivaldi and Brave

### DIFF
--- a/data/usr-share/bubblejail/profiles/chromium.toml
+++ b/data/usr-share/bubblejail/profiles/chromium.toml
@@ -5,6 +5,10 @@
 dot_desktop_path = [
     "/usr/share/applications/chromium-browser.desktop",
     "/usr/share/applications/chromium.desktop",
+    "/usr/share/applications/brave-browser.desktop",
+    "/usr/share/applications/brave-browser-beta.desktop",
+    "/usr/share/applications/brave-browser-nightly.desktop",
+    "/usr/share/applications/vivaldi-stable.desktop",
 ]
 description='''
 Chromium web browser


### PR DESCRIPTION
I installed those browsers to get the desktop entry names

this should detect brave, brave beta, brave nightly and vivaldi stable