### PR TITLE
Sort choices when generating manpages

### DIFF
--- a/docs/man_generator.py
+++ b/docs/man_generator.py
@@ -56,7 +56,7 @@ _EDITOR_ environmental variable must be set.
 """,
     "list": "\n".join(
         f"- *{x}*"
-        for x in BUBBLEJAIL_CMD["list"]["add_argument"]["list_what"]["choices"]
+        for x in sorted(BUBBLEJAIL_CMD["list"]["add_argument"]["list_what"]["choices"])
     ),
 }
 


### PR DESCRIPTION
The choices are stored in a set which causes the choices in the manpage to be shuffled around each time it is build. Sort the choices so they always have the same order.