### PR TITLE
Add sample profiles for common software

### DIFF
--- a/data/usr-share/bubblejail/profiles/chromium_wayland.toml
+++ b/data/usr-share/bubblejail/profiles/chromium_wayland.toml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 PACHAKUTlQ
+
+# Chromium on Wayland
+dot_desktop_path = [
+    "/usr/share/applications/chromium-browser.desktop",
+    "/usr/share/applications/chromium.desktop",
+]
+is_gtk_application = true
+description = '''
+Chromium web browser using Wayland display protocol.
+'''
+
+import_tips='''
+Manually add `/usr/bin/chromium --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-wayland-ime %U` to Chromium-bubblejail desktop entry to enable opening files or URL from CLI/double-clicking using Chromium.
+'''
+
+[services.common]
+executable_name = [
+    "/usr/bin/chromium",
+    "--enable-features=UseOzonePlatform",
+    "--ozone-platform=wayland",
+    "--enable-wayland-ime",
+    "%U",
+]
+share_local_time = false
+filter_disk_sync = false
+dbus_name = ""
+
+[services.wayland]
+
+[services.network]
+
+[services.pulse_audio]
+
+[services.home_share]
+# Add .config/chromium and .cache/chromium so Chromium can run both with/without sandbox without losing data
+home_paths = ["Downloads", ".config/chromium", ".cache/chromium"]
+
+[services.direct_rendering]
+enable_aco = false
+
+[services.notify]
+
+[services.pipewire]
+
+[services.v4l]
+
+[services.fcitx]

--- a/data/usr-share/bubblejail/profiles/localsend.toml
+++ b/data/usr-share/bubblejail/profiles/localsend.toml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 PACHAKUTlQ
+
+# Localsend
+dot_desktop_path = ["/usr/share/applications/localsend.desktop"]
+description = '''
+Localsend local file sharing
+'''
+
+[services.common]
+executable_name = ["/usr/bin/localsend"]
+share_local_time = false
+filter_disk_sync = false
+dbus_name = ""
+
+[services.wayland]
+
+[services.network]
+
+[services.home_share]
+home_paths = ["Downloads"]

--- a/data/usr-share/bubblejail/profiles/telegram.toml
+++ b/data/usr-share/bubblejail/profiles/telegram.toml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 PACHAKUTlQ
+
+# Telegram desktop
+dot_desktop_path = [
+    "/usr/share/applications/org.telegram.desktop.desktop",
+    "/usr/share/applications/telegram-desktop.desktop",
+    "/usr/share/applications/telegram.desktop",
+]
+description = '''
+Telegram desktop
+'''
+
+[services.common]
+executable_name = ["/usr/bin/telegram-desktop"]
+share_local_time = false
+filter_disk_sync = false
+dbus_name = "org.telegram.*"
+
+[services.wayland]
+
+[services.network]
+
+[services.pulse_audio]
+
+[services.home_share]
+home_paths = ["Downloads"]
+
+[services.systray]
+
+[services.notify]
+
+[services.fcitx]

--- a/data/usr-share/bubblejail/profiles/thunderbird_wayland.toml
+++ b/data/usr-share/bubblejail/profiles/thunderbird_wayland.toml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 PACHAKUTlQ
+
+# Thunderbird on Wayland
+dot_desktop_path = [
+    "/usr/share/applications/org.mozilla.Thunderbird.desktop",
+    "/usr/share/applications/thunderbird.desktop",
+    "/usr/share/applications/Thunderbird.desktop",
+]
+is_gtk_application = true
+description = '''
+Thunderbird client using Wayland display protocol.
+'''
+
+[services.common]
+executable_name = "/usr/bin/thunderbird"
+share_local_time = false
+filter_disk_sync = false
+dbus_name = "org.mozilla.Thunderbird"
+
+[services.wayland]
+
+[services.network]
+
+[services.home_share]
+home_paths = ["Downloads", ".mozilla", ".pki/nssdb"]
+
+[services.notify]
+
+[services.fcitx]

--- a/data/usr-share/bubblejail/profiles/tor_browser_wayland.toml
+++ b/data/usr-share/bubblejail/profiles/tor_browser_wayland.toml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 PACHAKUTlQ
+
+# Tor browser on Wayland
+dot_desktop_path = "/usr/share/applications/tor-browser.desktop"
+is_gtk_application = true
+description = '''
+Tor browser using Wayland display protocol.
+'''
+
+[services.common]
+executable_name = "/usr/bin/tor-browser"
+share_local_time = false
+filter_disk_sync = false
+dbus_name = ""
+
+[services.wayland]
+
+[services.network]
+
+[services.pulse_audio]
+
+[services.home_share]
+home_paths = ["Downloads", ".local/share/torbrowser", ".local/opt/tor-browser"]
+
+[services.direct_rendering]
+enable_aco = false
+
+[services.fcitx]

--- a/data/usr-share/bubblejail/profiles/typora.toml
+++ b/data/usr-share/bubblejail/profiles/typora.toml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 PACHAKUTlQ
+
+# Typora markdown editor
+dot_desktop_path = ["/usr/share/applications/typora.desktop"]
+description = '''
+Typora markdown editor
+'''
+
+import_tips = '''
+Manually add `/usr/bin/typora --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-wayland-ime %F` to Typora-bubblejail desktop entry to enable opening files from CLI/double-clicking using Typora.
+'''
+
+[services.common]
+executable_name = [
+    "/usr/bin/typora",
+    "--enable-features=UseOzonePlatform",
+    "--ozone-platform=wayland",
+    "--enable-wayland-ime",
+    "%F",
+]
+share_local_time = false
+filter_disk_sync = false
+dbus_name = ""
+
+[services.wayland]
+
+[services.network]
+
+[services.home_share]
+home_paths = ["Downloads", "Documents"]
+
+[services.direct_rendering]
+enable_aco = false
+
+[services.fcitx]

--- a/data/usr-share/bubblejail/profiles/zotero.toml
+++ b/data/usr-share/bubblejail/profiles/zotero.toml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 PACHAKUTlQ
+
+# Zotero
+dot_desktop_path = ["/usr/share/applications/zotero.desktop"]
+description = '''
+Zotero reference manager
+'''
+
+[services.common]
+executable_name = ["/usr/bin/zotero", "-url %U"]
+share_local_time = false
+filter_disk_sync = false
+dbus_name = ""
+
+[services.wayland]
+
+[services.network]
+
+[services.home_share]
+home_paths = ["Zotero", "Downloads"]
+
+[services.systray]
+
+[services.notify]
+
+[services.fcitx]


### PR DESCRIPTION
# Add profiles for common software

Add profiles for Chromium Wayland, Localsend, Telegram desktop, Thunderbird, Tor browser, Typora and Zotero.

> [!warning]
>
> As there are no guides of writing sample profiles, I wrote them based on the `services.toml` in bubblejail instance folders. There are differences between `services.toml` and the toml configs of sample profiles, so I wrote these based on existing profiles, but am not sure they are all correct.
>
> The services.toml in bubblejail instance folders all work on Arch Linux and latest Ubuntu, but the sample profiles **ARE NOT** fully tested, as I don't want to mess up with my local sandbox environments which took very much trouble to config. Please test before merge.

All the added profiles use wayland if possible and has least access to privileges and paths.

Some software like Chromium and Chromium-based browsers and APPs originally supports opening files by `chromium some_file`, but I cannot find a way to allow this using bubblejail configs alone. (Adding `%F` or `%U` in `[common]` -> `executable_name` does not work.)

So I use a workaround of adding flags in desktop entry files like:
```toml
[Desktop Entry]
Exec=bubblejail run chromium_bubblejail_instance chromium --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-wayland-ime %U
```
to enable opening files from CLI/double-clicking using Chromium. When using this workaround, the fields in `[common]` in bubblejail config is not needed.

Running Chromium using wayland on Arch Linux may require manually install `gtk3`, or may crash.