### PR TITLE
Don't unconditionally bind /opt

### DIFF
--- a/src/bubblejail/services.py
+++ b/src/bubblejail/services.py
@@ -176,7 +176,7 @@ class BubblejailDefaults(BubblejailService):
     def iter_bwrap_options(self) -> ServiceGeneratorType:
         # Distro packaged libraries and binaries
         yield ReadOnlyBind("/usr")
-        yield ReadOnlyBind("/opt")
+        yield ReadOnlyBindTry("/opt")
         # Recreate symlinks in / or mount them read-only if its not a symlink.
         # Should be portable between distros.
         for root_path in Path("/").iterdir():


### PR DESCRIPTION
Since /opt should not be managed by the package manager, it should not be neccesary for bubblejail to be able to bind this directory. Therefore only ro-bind-try as lacking this directory should not be fatal.