### PR TITLE
Fix xdg-settings-portal pretty_name

### DIFF
--- a/src/bubblejail/services.py
+++ b/src/bubblejail/services.py
@@ -1434,7 +1434,7 @@ class XdgDesktopPortalSettings:
     settings: bool = field(
         default=True,
         metadata=SettingFieldMetadata(
-            pretty_name="Enable Trash portal",
+            pretty_name="Enable Settings portal",
             description=(
                 "Enable Settings portal which allows "
                 "reading common GUI settings like dark mode."


### PR DESCRIPTION
This fixes xdg-settings-portal pretty_name being copied from xdg-trash-portal. It also fixes all xdg-portal checkboxes being unchecked, no matter what the actual value of the toggle is. However, I am not sure this is the best fix, just the first solution that came to mind.