### PR TITLE
Implement a instance creation hook for `BubblejailService`s

### DIFF
--- a/src/bubblejail/bubblejail_directories.py
+++ b/src/bubblejail/bubblejail_directories.py
@@ -137,8 +137,6 @@ class BubblejailDirectories:
 
         # Exception will be raised if directory already exists
         instance_directory.mkdir(mode=0o700, parents=True)
-        # Make home directory
-        (instance_directory / "home").mkdir(mode=0o700)
 
         # Profile
         profile: BubblejailProfile = (

--- a/src/bubblejail/services.py
+++ b/src/bubblejail/services.py
@@ -313,6 +313,10 @@ class BubblejailDefaults(BubblejailService):
             dbus_session_inside_path,
         )
 
+    def create_hook(self, parent: BubblejailInstance) -> None:
+        # Make home directory
+        parent.path_home_directory.mkdir(mode=0o700)
+
     def __repr__(self) -> str:
         return "Bubblejail defaults."
 


### PR DESCRIPTION
Some `BubblejailServices` may, in the future, want to perform pre-configuration of the jail at instantiation time.

This series implements a simple `create_hook` interface that is called at profile creation time.  The second patch movies the home directory creation to that hook implemented in the `BubblejailDefaults`.

I'm suggesting this (and the other `BubblejailService` sequence) because (proximately) I am trying to get bubblejail working with SELinux, and I would like the ability to create some directories ahead of time.  Specifically, bubblewrap will try to create directories inside the jailed namespace, and since it is running as a `bubblewrap_<user>_t`, and not `<user>_t`, it would need to be given significant additional rules/authority to properly create and label those directories.

I have a policy that labels `${HOME}/.local/share/bubblejail/instances/${INSTANCENAME}` in such a way that the `home` subdirectory naturally get the `user_home_dir_t` label needed for the jailed process to behave correctly.  Other directories under there (e.g., `.config`) will then naturally get the right SELinux label if they are created by the bubblejail process (but not the bubblewrap process).  I would like to be able to nicely put those `mkdir`s in other, appropriate, `create_hook`s.

A slight variation of this patch is to call the `create_hook` `prepare_hook`, and make its action "idempotent" (i.e., set `exist_ok=True`, and re-set the permissions on the directory) so that a "reconfiguration" of the instance could be done as a potential new feature.

Alternatively, we could just unconditionally run that idempotent hook at instance startup.  In that case, I would want to put the aforementioned `mkdir`s in the startup hooks of the appropriate services.