### PR TITLE
Fix DefaultServices only having access to empty ServicesConfig

### DIFF
--- a/src/bubblejail/services.py
+++ b/src/bubblejail/services.py
@@ -1627,10 +1627,12 @@ class ServiceContainer:
         self.services_config = ServicesConfig()
         self.services: dict[str, BubblejailService] = {}
 
-        self.default_service = BubblejailDefaults(self.services_config)
-
         if conf_dict is not None:
             self.set_services(conf_dict)
+
+        # Initialize default service only after the self.services_config
+        # is loaded.
+        self.default_service = BubblejailDefaults(self.services_config)
 
     def set_services(self, new_services_datas: ServicesConfDictType) -> None:
 


### PR DESCRIPTION
`ServiceContainer.set_services` overwrites `services_config`, which has the effect of `default_service` becoming stale (since it refers to the empty dummy `ServicesConfig`, which contains no settings data).

This patch ensures that `services_config` is properly initialized before using it to create `default_service`.

This is (merely) a latent issue, since nothing in BubblejailDefaults actually uses the services_config that it is passed, but future changes might change that.  Also, this is a very (**very**) slight performance improvement, since it removes a single unnecessary object creation.