### PR TITLE
Add tags to bubblejail-config.desktop

### DIFF
--- a/data/bubblejail-config.desktop
+++ b/data/bubblejail-config.desktop
@@ -5,4 +5,5 @@ Type=Application
 Name=Bubblejail Configuration
 Icon=bubblejail-config
 Exec=bubblejail-config
+Keywords=bwrap;bubblewrap;sandbox;
 Categories=Settings;


### PR DESCRIPTION
So now it is searchable through apps list by bubblewrap name.
<img width="519" height="134" alt="bjail" src="https://github.com/user-attachments/assets/3c518311-816d-424a-af6a-bc06aac07de9" />

