### PR TITLE
Add read-only mount support for home_share through "home_paths_read_only"

### DIFF
--- a/src/bubblejail/services.py
+++ b/src/bubblejail/services.py
@@ -531,6 +531,13 @@ class HomeShareSettings:
             description="Path to share with sandbox",
         ),
     )
+    home_paths_ro: list[str] = field(
+        default_factory=list,
+        metadata=SettingFieldMetadata(
+            pretty_name="List of read-only paths",
+            description="Path to share as read-only with sandbox",
+        ),
+    )
 
 
 class HomeShare(BubblejailService):
@@ -543,6 +550,11 @@ class HomeShare(BubblejailService):
 
         for path_relative_to_home in settings.home_paths:
             yield Bind(
+                Path.home() / path_relative_to_home,
+            )
+
+        for path_relative_to_home in settings.home_paths_ro:
+            yield ReadOnlyBind(
                 Path.home() / path_relative_to_home,
             )
 

--- a/src/bubblejail/services.py
+++ b/src/bubblejail/services.py
@@ -531,7 +531,7 @@ class HomeShareSettings:
             description="Path to share with sandbox",
         ),
     )
-    home_paths_ro: list[str] = field(
+    home_paths_read_only: list[str] = field(
         default_factory=list,
         metadata=SettingFieldMetadata(
             pretty_name="List of read-only paths",
@@ -553,7 +553,7 @@ class HomeShare(BubblejailService):
                 Path.home() / path_relative_to_home,
             )
 
-        for path_relative_to_home in settings.home_paths_ro:
+        for path_relative_to_home in settings.home_paths_read_only:
             yield ReadOnlyBind(
                 Path.home() / path_relative_to_home,
             )


### PR DESCRIPTION
See: #111

Now, a snippet like this works as expected:
```
[home_share]
home_paths = [
    "Downloads",
    ".config/zen",
    ".cache/zen"
]
home_paths_read_only = [
    ".themes",
    ".config/gtk-3.0"
]
```